### PR TITLE
fix(missing image): fix missing image issue on the products catalog

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Fixing the issue happening when the user selects a product without specifying its related image by adding the fallback to the placeholder image

<img width="560" alt="Screen Shot 2022-09-14 at 11 19 14 PM" src="https://user-images.githubusercontent.com/34940230/190264777-54d82728-613e-477e-928c-5310bc330bd5.png">
